### PR TITLE
Removed Kotlin Android Extensions Plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id(BuildPlugins.androidApplication)
     id(BuildPlugins.kotlinAndroid)
-    id(BuildPlugins.kotlinAndroidExtensions)
+    id(BuildPlugins.kotlinParcelizePlugin)
     id(BuildPlugins.ktlintPlugin)
     id(BuildPlugins.jacocoAndroid)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     id(BuildPlugins.androidLibrary) apply false
     id(BuildPlugins.androidApplication) apply false
     id(BuildPlugins.kotlinAndroid) apply false
-    id(BuildPlugins.kotlinAndroidExtensions) apply false
     id(BuildPlugins.dokkaPlugin) version Versions.dokka
     id(BuildPlugins.gradleVersionsPlugin) version Versions.gradleVersionsPlugin
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,7 +1,7 @@
 object Versions {
 
     //Version codes for all the libraries
-    const val kotlin = "1.4.10"
+    const val kotlin = "1.4.21"
     const val buildToolsVersion = "4.1.0"
     const val appCompat = "1.3.0-alpha02"
     const val constraintLayout = "2.0.4"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@ object Versions {
 
     //Version codes for all the libraries
     const val kotlin = "1.4.21"
-    const val buildToolsVersion = "4.1.0"
+    const val buildToolsVersion = "4.1.1"
     const val appCompat = "1.3.0-alpha02"
     const val constraintLayout = "2.0.4"
     const val ktx = "1.5.0-alpha05"
@@ -32,7 +32,7 @@ object BuildPlugins {
     const val dokkaPlugin = "org.jetbrains.dokka"
     const val androidApplication = "com.android.application"
     const val kotlinAndroid = "org.jetbrains.kotlin.android"
-    const val kotlinAndroidExtensions = "org.jetbrains.kotlin.android.extensions"
+    const val kotlinParcelizePlugin = "org.jetbrains.kotlin.plugin.parcelize"
     const val gradleVersionsPlugin = "com.github.ben-manes.versions"
     const val jacocoAndroid = "com.hiya.jacoco-android"
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,22 +3,22 @@ object Versions {
     //Version codes for all the libraries
     const val kotlin = "1.4.21"
     const val buildToolsVersion = "4.1.1"
-    const val appCompat = "1.3.0-alpha02"
-    const val constraintLayout = "2.0.4"
-    const val ktx = "1.5.0-alpha05"
-    const val material = "1.3.0-alpha03"
+    const val appCompat = "1.3.0-beta01"
+    const val constraintLayout = "2.1.0-alpha2"
+    const val ktx = "1.5.0-beta01"
+    const val material = "1.3.0-rc01"
 
     //Version codes for all the test libraries
     const val junit4 = "4.13.1"
-    const val testRunner = "1.3.1-alpha02"
-    const val espresso = "3.4.0-alpha02"
-    const val annotation = "1.2.0-alpha01"
+    const val testRunner = "1.3.1-alpha03"
+    const val espresso = "3.4.0-alpha03"
+    const val annotation = "1.2.0-beta01"
 
     // Gradle Plugins
     const val ktlint = "9.4.1"
     const val detekt = "1.14.2"
-    const val spotless = "5.8.2"
-    const val dokka = "1.4.10.2"
+    const val spotless = "5.9.0"
+    const val dokka = "1.4.20"
     const val gradleVersionsPlugin = "0.36.0"
     const val jacoco = "0.8.4"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,10 +7,9 @@ pluginManagement {
     }
 
     plugins {
-        id("com.android.application") version "4.1.0"
-        id("org.jetbrains.kotlin.android") version "1.4.10"
-        id("org.jetbrains.kotlin.android.extensions") version "1.4.10"
-        id("com.android.library") version "4.1.0"
+        id("com.android.application") version "4.1.1"
+        id("org.jetbrains.kotlin.android") version "1.4.21"
+        id("com.android.library") version "4.1.1"
         id("com.google.firebase.crashlytics") version "2.1.0"
     }
 


### PR DESCRIPTION
This PR addresses the removal of the Android Extensions Plugin to use the new Parcelize Plugin.

Most Notable Changes:
- Parcelize Plugin does not need to be defined on project level `build.gradle.kts` file
- Parcelize Plugin does not need to be added on the `settings.gradle.kts` file too as it's predecessor.